### PR TITLE
Silence warning about CGI::param in list context

### DIFF
--- a/lib/CGI/Ex.pm
+++ b/lib/CGI/Ex.pm
@@ -127,6 +127,8 @@ sub get_form {
     ### get the info out of the object
     my $obj  = shift || $self->object;
     my %hash = ();
+    ### this particular use of $cgi->param in list context is safe
+    local $CGI::LIST_CONTEXT_WARN = 0;
     foreach my $key ($obj->param) {
         my @val = $obj->param($key);
         $hash{$key} = ($#val <= 0) ? $val[0] : \@val;


### PR DESCRIPTION
CGI 4.05 (released in 2014-10-08) added a warning for the use of CGI's param method in list context, the improper use of which can lead to security problems. A mechanism was also included to turn off the warning for cases that are not improper. Then the multi_param method was created as a safer replacement for param.

The param method is already used safely in CGI::Ex, and rather than switch to multi_param yet and require such a recent CGI, this patch just silences the warning.
