### PR TITLE
Fix bug preventing logging out if bouncing

### DIFF
--- a/lib/CGI/Ex/Auth.pm
+++ b/lib/CGI/Ex/Auth.pm
@@ -54,7 +54,7 @@ sub get_valid_auth {
 
         if ($self->bounce_on_logout) {
             my $key_c = $self->key_cookie;
-            $self->delete_cookie({key => $key_c}) if $self->cookies->{$key_c};
+            $self->delete_cookie({name => $key_c}) if $self->cookies->{$key_c};
             my $user = $self->last_auth_data ? $self->last_auth_data->{'user'} : undef;
             $self->location_bounce($self->logout_redirect(defined($user) ? $user : ''));
             eval { die "Logging out" };


### PR DESCRIPTION
A parameter key to the CGI::Ex::Auth delete_cookie method is wrongly used in that same module. The result is that, if the bounce_on_logout functionality is used, it won't actually delete the auth cookie, and the user will bounce but still be logged in. The correct key name is "name" instead of "key".

See:
- https://github.com/chazmcgarvey/CGI-Ex/blob/ccm-bugfix-auth-bounce_on_logout/lib/CGI/Ex/Auth.pm#L279
