### PR TITLE
Replace set-cookie in meta with equivalent script

### DIFF
--- a/lib/CGI/Ex.pm
+++ b/lib/CGI/Ex.pm
@@ -357,7 +357,7 @@ sub set_cookie {
     my $cookie = "" . $obj->cookie(%$args);
 
     if ($self->content_typed) {
-        print "<script>document.cookie = '$cookie'</script>";
+        print "<script>document.cookie = '$cookie'</script>\n";
     } else {
         if (my $r = $self->apache_request) {
             if ($self->is_mod_perl_1) {

--- a/lib/CGI/Ex.pm
+++ b/lib/CGI/Ex.pm
@@ -357,7 +357,7 @@ sub set_cookie {
     my $cookie = "" . $obj->cookie(%$args);
 
     if ($self->content_typed) {
-        print "<meta http-equiv=\"Set-Cookie\" content=\"$cookie\" />\n";
+        print "<script>document.cookie = '$cookie'</script>";
     } else {
         if (my $r = $self->apache_request) {
             if ($self->is_mod_perl_1) {


### PR DESCRIPTION
`<meta http-equiv=set-cookie>` has been removed from the HTML standard
over security concerns and is already ignored by some implementors.

Ref: https://github.com/whatwg/html/issues/3076

Thanks @thaabit, @selftaught, Alfredo Cabrera, and Matt Swensen.