### PR TITLE
Issue 16

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2.48
+    2018-12-06
+        * Fix app constants on modern perls.
+
 2.47
     2018-08-16
         * Replace mechanism for setting cookies via meta tags with JavaScript equivalent (thanks to Garth Hill, Dillan Hildebrand, Alfredo Cabrera, Matt Swensen)

--- a/META.json
+++ b/META.json
@@ -43,7 +43,6 @@
       "test" : {
          "requires" : {
             "Test::More" : "0",
-            "Test::Warn" : "0"
          }
       }
    },

--- a/META.yml
+++ b/META.yml
@@ -5,7 +5,6 @@ author:
 build_requires:
   ExtUtils::MakeMaker: '0'
   Test::More: '0'
-  Test::Warn: '0'
 configure_requires:
   ExtUtils::MakeMaker: '0'
 dynamic_config: 1

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,7 +39,6 @@ WriteMakefile1(
               },
               TEST_REQUIRES => {
                 'Test::More' => '0',
-                'Test::Warn' => '0',
               },
 
               dist          => {

--- a/lib/CGI/Ex.pm
+++ b/lib/CGI/Ex.pm
@@ -15,17 +15,17 @@ CGI::Ex - CGI utility suite - makes powerful application writing fun and easy
 
 use 5.006;
 use strict;
-our ($VERSION,
-     $PREFERRED_CGI_MODULE,
+our $VERSION = '2.48';
+
+our ($PREFERRED_CGI_MODULE,
      $PREFERRED_CGI_REQUIRED,
      $AUTOLOAD,
      $DEBUG_LOCATION_BOUNCE,
      @EXPORT, @EXPORT_OK
      );
-use base qw(Exporter);
+use Exporter qw(import);
 
 BEGIN {
-    $VERSION               = '2.47';
     $PREFERRED_CGI_MODULE  ||= 'CGI';
     @EXPORT = ();
     @EXPORT_OK = qw(get_form

--- a/lib/CGI/Ex/App.pm
+++ b/lib/CGI/Ex/App.pm
@@ -10,7 +10,7 @@ BEGIN {
     eval { use Time::HiRes qw(time) };
     eval { use Scalar::Util };
 }
-our $VERSION = '2.47';
+our $VERSION = '2.48';
 
 sub croak { die sprintf "%s at %3\$s line %4\$s\n", $_[0], caller 1 }
 

--- a/lib/CGI/Ex/App/Constants.pm
+++ b/lib/CGI/Ex/App/Constants.pm
@@ -6,13 +6,15 @@ CGI::Ex::App::Constants - Easier access to magic App values
 
 =cut
 
-use vars qw(%constants @EXPORT @EXPORT_OK %EXPORT_TAGS $VERSION);
 use strict;
 use warnings;
 use Exporter qw(import); # allow for goto from CGI::Ex::App
-use base qw(Exporter);
 
-$VERSION = '2.47';
+our $VERSION = '2.48';
+our %constants;
+our @EXPORT;
+our @EXPORT_OK;
+our %EXPORT_TAGS;
 
 BEGIN {
 my $all = {
@@ -86,7 +88,7 @@ my $all = {
     App__validate_when_data__use_ready_validate   => 0,
 };
 
-no strict 'refs';
+require constant;
 while (my ($method, $val) = each %$all) {
     my ($prefix, $tag, $name) = split /__/, $method;
     if (! $name) {
@@ -103,7 +105,7 @@ while (my ($method, $val) = each %$all) {
 
     $val =~ s/\s+-.*//;
     $val *= 1 if $val =~ /^\d+$/;
-    *{__PACKAGE__."::$method"} = sub () { $val };
+    import constant $method => $val;
 }
 
 }; # end of BEGIN

--- a/lib/CGI/Ex/Auth.pm
+++ b/lib/CGI/Ex/Auth.pm
@@ -12,14 +12,14 @@ CGI::Ex::Auth - Handle logins nicely.
 ###----------------------------------------------------------------###
 
 use strict;
-use vars qw($VERSION);
+#use warnings; # TODO - investigate enabling in heavy usage scenarios
 
 use MIME::Base64 qw(encode_base64 decode_base64);
 use Digest::MD5 qw(md5_hex);
 use CGI::Ex;
 use Carp qw(croak);
 
-$VERSION = '2.47';
+our $VERSION = '2.48';
 
 ###----------------------------------------------------------------###
 

--- a/lib/CGI/Ex/Conf.pm
+++ b/lib/CGI/Ex/Conf.pm
@@ -12,69 +12,67 @@ CGI::Ex::Conf - Conf Reader/Writer for many different data format types
 ###----------------------------------------------------------------###
 
 use strict;
-use base qw(Exporter);
+use warnings;
+use Exporter qw(import);
 use Carp qw(croak);
-use vars qw($VERSION
-            @DEFAULT_PATHS
-            $DEFAULT_EXT
-            %EXT_READERS
-            %EXT_WRITERS
-            $DIRECTIVE
-            $IMMUTABLE_QR
-            $IMMUTABLE_KEY
-            %CACHE
-            $HTML_KEY
-            @EXPORT_OK
-            $NO_WARN_ON_FAIL
-            );
-@EXPORT_OK = qw(conf_read conf_write in_cache);
 
-$VERSION = '2.47';
+our @EXPORT_OK = qw(conf_read conf_write in_cache);
 
-$DEFAULT_EXT = 'conf';
+our $VERSION = '2.48';
 
-%EXT_READERS = (''         => \&read_handler_yaml,
-                'conf'     => \&read_handler_yaml,
-                'json'     => \&read_handler_json,
-                'val_json' => \&read_handler_json,
-                'ini'      => \&read_handler_ini,
-                'pl'       => \&read_handler_pl,
-                'sto'      => \&read_handler_storable,
-                'storable' => \&read_handler_storable,
-                'val'      => \&read_handler_yaml,
-                'xml'      => \&read_handler_xml,
-                'yaml'     => \&read_handler_yaml,
-                'yml'      => \&read_handler_yaml,
-                'html'     => \&read_handler_html,
-                'htm'      => \&read_handler_html,
-                );
+our $DEFAULT_EXT = 'conf';
+our @DEFAULT_PATHS;
 
-%EXT_WRITERS = (''         => \&write_handler_yaml,
-                'conf'     => \&write_handler_yaml,
-                'ini'      => \&write_handler_ini,
-                'json'     => \&write_handler_json,
-                'val_json' => \&write_handler_json,
-                'pl'       => \&write_handler_pl,
-                'sto'      => \&write_handler_storable,
-                'storable' => \&write_handler_storable,
-                'val'      => \&write_handler_yaml,
-                'xml'      => \&write_handler_xml,
-                'yaml'     => \&write_handler_yaml,
-                'yml'      => \&write_handler_yaml,
-                'html'     => \&write_handler_html,
-                'htm'      => \&write_handler_html,
-                );
+our %EXT_READERS = (
+    ''         => \&read_handler_yaml,
+    'conf'     => \&read_handler_yaml,
+    'json'     => \&read_handler_json,
+    'val_json' => \&read_handler_json,
+    'ini'      => \&read_handler_ini,
+    'pl'       => \&read_handler_pl,
+    'sto'      => \&read_handler_storable,
+    'storable' => \&read_handler_storable,
+    'val'      => \&read_handler_yaml,
+    'xml'      => \&read_handler_xml,
+    'yaml'     => \&read_handler_yaml,
+    'yml'      => \&read_handler_yaml,
+    'html'     => \&read_handler_html,
+    'htm'      => \&read_handler_html,
+    );
+
+our %EXT_WRITERS = (
+    ''         => \&write_handler_yaml,
+    'conf'     => \&write_handler_yaml,
+    'ini'      => \&write_handler_ini,
+    'json'     => \&write_handler_json,
+    'val_json' => \&write_handler_json,
+    'pl'       => \&write_handler_pl,
+    'sto'      => \&write_handler_storable,
+    'storable' => \&write_handler_storable,
+    'val'      => \&write_handler_yaml,
+    'xml'      => \&write_handler_xml,
+    'yaml'     => \&write_handler_yaml,
+    'yml'      => \&write_handler_yaml,
+    'html'     => \&write_handler_html,
+    'htm'      => \&write_handler_html,
+    );
 
 ### $DIRECTIVE controls how files are looked for when namespaces are not absolute.
 ### If directories 1, 2 and 3 are passed and each has a config file
 ### LAST would return 3, FIRST would return 1, and MERGE will
 ### try to put them all together.  Merge behavior of hashes
 ### is determined by $IMMUTABLE_\w+ variables.
-$DIRECTIVE = 'LAST'; # LAST, MERGE, FIRST
+our $DIRECTIVE = 'LAST'; # LAST, MERGE, FIRST
 
-$IMMUTABLE_QR = qr/_immu(?:table)?$/i;
+our $IMMUTABLE_QR = qr/_immu(?:table)?$/i;
 
-$IMMUTABLE_KEY = 'immutable';
+our $IMMUTABLE_KEY = 'immutable';
+
+our $NO_WARN_ON_FAIL;
+
+our $HTML_KEY;
+
+our %CACHE;
 
 ###----------------------------------------------------------------###
 

--- a/lib/CGI/Ex/Die.pm
+++ b/lib/CGI/Ex/Die.pm
@@ -12,18 +12,17 @@ CGI::Ex::Die - A CGI::Carp::FatalsToBrowser type utility.
 ###----------------------------------------------------------------###
 
 use strict;
-use vars qw($VERSION
-            $no_recurse
-            $EXTENDED_ERRORS $SHOW_TRACE $IGNORE_EVAL
-            $ERROR_TEMPLATE
-            $LOG_HANDLER $FINAL_HANDLER
-            );
-
+use vars qw($EXTENDED_ERRORS $SHOW_TRACE $IGNORE_EVAL);
 use CGI::Ex;
 use CGI::Ex::Dump qw(debug ctrace dex_html);
 
+our $VERSION = '2.48';
+our $no_recurse;
+our $ERROR_TEMPLATE;
+our $LOG_HANDLER;
+our $FINAL_HANDLER;
+
 BEGIN {
-  $VERSION = '2.47';
   $SHOW_TRACE = 0      if ! defined $SHOW_TRACE;
   $IGNORE_EVAL = 0     if ! defined $IGNORE_EVAL;
   $EXTENDED_ERRORS = 1 if ! defined $EXTENDED_ERRORS;

--- a/lib/CGI/Ex/Dump.pm
+++ b/lib/CGI/Ex/Dump.pm
@@ -11,16 +11,13 @@ CGI::Ex::Dump - A debug utility
 #  Distributed under the Perl Artistic License without warranty      #
 ###----------------------------------------------------------------###
 
-use vars qw(@ISA @EXPORT @EXPORT_OK $VERSION
-            $CALL_LEVEL
-            $ON $SUB $QR1 $QR2 $full_filename $DEPARSE);
+use vars qw($CALL_LEVEL $ON $SUB $QR1 $QR2 $full_filename $DEPARSE);
 use strict;
-use Exporter;
+use Exporter qw(import);
 
-$VERSION   = '2.47';
-@ISA       = qw(Exporter);
-@EXPORT    = qw(dex dex_warn dex_text dex_html ctrace dex_trace);
-@EXPORT_OK = qw(dex dex_warn dex_text dex_html ctrace dex_trace debug caller_trace);
+our $VERSION = '2.48';
+our @EXPORT    = qw(dex dex_warn dex_text dex_html ctrace dex_trace);
+our @EXPORT_OK = qw(dex dex_warn dex_text dex_html ctrace dex_trace debug caller_trace);
 
 ### is on or off
 sub on  { $ON = 1 };

--- a/lib/CGI/Ex/Fill.pm
+++ b/lib/CGI/Ex/Fill.pm
@@ -12,35 +12,24 @@ CGI::Ex::Fill - Fast but compliant regex based form filler
 ###----------------------------------------------------------------###
 
 use strict;
-use vars qw($VERSION
-            @EXPORT @EXPORT_OK
-            $REMOVE_SCRIPT
-            $REMOVE_COMMENT
-            $MARKER_SCRIPT
-            $MARKER_COMMENT
-            $OBJECT_METHOD
-            $_TEMP_TARGET
-            );
-use base qw(Exporter);
+use warnings;
+use Exporter qw(import);
 
-BEGIN {
-    $VERSION   = '2.47';
-    @EXPORT    = qw(form_fill);
-    @EXPORT_OK = qw(fill form_fill html_escape get_tagval_by_key swap_tagval_by_key);
-};
+our $VERSION = '2.48';
+our @EXPORT    = qw(form_fill);
+our @EXPORT_OK = qw(fill form_fill html_escape get_tagval_by_key swap_tagval_by_key);
 
 ### These directives are used to determine whether or not to
 ### remove html comments and script sections while filling in
 ### a form.  Default is on.  This may give some trouble if you
 ### have a javascript section with form elements that you would
 ### like filled in.
-BEGIN {
-    $REMOVE_SCRIPT  = 1;
-    $REMOVE_COMMENT = 1;
-    $MARKER_SCRIPT  = "\0SCRIPT\0";
-    $MARKER_COMMENT = "\0COMMENT\0";
-    $OBJECT_METHOD  = "param";
-};
+our $REMOVE_SCRIPT  = 1;
+our $REMOVE_COMMENT = 1;
+our $MARKER_SCRIPT  = "\0SCRIPT\0";
+our $MARKER_COMMENT = "\0COMMENT\0";
+our $OBJECT_METHOD  = "param";
+our $_TEMP_TARGET;
 
 ###----------------------------------------------------------------###
 

--- a/lib/CGI/Ex/JSONDump.pm
+++ b/lib/CGI/Ex/JSONDump.pm
@@ -11,18 +11,12 @@ CGI::Ex::JSONDump - Comprehensive data to JSON dump.
 #  Distributed under the Perl Artistic License without warranty      #
 ###----------------------------------------------------------------###
 
-use vars qw($VERSION
-            @EXPORT @EXPORT_OK);
 use strict;
-use base qw(Exporter);
+use Exporter qw(import);
 
-BEGIN {
-    $VERSION = '2.47';
-
-    @EXPORT = qw(JSONDump);
-    @EXPORT_OK = @EXPORT;
-
-};
+our $VERSION = '2.48';
+our @EXPORT = qw(JSONDump);
+our @EXPORT_OK = @EXPORT;
 
 sub JSONDump {
     my ($data, $args) = @_;

--- a/lib/CGI/Ex/Template.pm
+++ b/lib/CGI/Ex/Template.pm
@@ -10,22 +10,8 @@ use strict;
 use warnings;
 use Template::Alloy 1.016;
 use base qw(Template::Alloy);
-use vars qw($VERSION
-            $QR_PRIVATE
-            $WHILE_MAX
-            $MAX_EVAL_RECURSE
-            $MAX_MACRO_RECURSE
-            $STAT_TTL
-            $EXTRA_COMPILE_EXT
-            $PERL_COMPILE_EXT
-            $SCALAR_OPS
-            $FILTER_OPS
-            $LIST_OPS
-            $HASH_OPS
-            $VOBJS
-            );
 
-$VERSION = '2.47';
+our $VERSION = '2.48';
 
 ### install true symbol table aliases that can be localized
 *QR_PRIVATE        = *Template::Alloy::QR_PRIVATE;

--- a/lib/CGI/Ex/Validate.pm
+++ b/lib/CGI/Ex/Validate.pm
@@ -6,9 +6,10 @@ package CGI::Ex::Validate;
 #  Distributed under the Perl Artistic License without warranty
 
 use strict;
+use warnings;
 use Carp qw(croak);
 
-our $VERSION  = '2.47';
+our $VERSION = '2.48';
 our $QR_EXTRA = qr/^(\w+_error|as_(array|string|hash)_\w+|no_\w+)/;
 our @UNSUPPORTED_BROWSERS = (qr/MSIE\s+5.0\d/i);
 our $JS_URI_PATH;

--- a/t/1_validate_12_change.t
+++ b/t/1_validate_12_change.t
@@ -7,8 +7,8 @@
 =cut
 
 use strict;
+use warnings;
 use Test::More tests => 12;
-use Test::Warn;
 
 use_ok('CGI::Ex::Validate');
 my $e;
@@ -86,7 +86,12 @@ is($form->{'key3'}, '23', "Non-global is fine");
         },
     };
 
-    local $^W = 1;  # enable warnings
-    warning_is { $e = validate($form, $v) } undef, 'No warnings';
+    my @warn;
+    local $SIG{'__WARN__'} = sub { push @warn, [@_] };
+
+    warn "Before\n";
+    $e = validate($form, $v);
+    warn "After\n";
+    is_deeply(\@warn, [["Before\n"], ["After\n"]], 'No warnings');
     ok(! $e, 'No error');
 }


### PR DESCRIPTION
Update constants to "use constant" for setting values.  This avoids deprecation warnings about
using lexicals in constant subs ().  Add tests for constants.  Also remove most instances
of use vars, change items to only import import (not inherit Exporter), and remove need for
Test::Warn.