### PR TITLE
Add HttpOnly, SameSite support to CGI::Ex::Auth

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -95,4 +95,5 @@ t/5_dump_00_base.t
 t/6_die_00_base.t
 t/7_template_00_base.t
 t/8_auth_00_base.t
+t/8_auth_01_cookies.t
 t/9_jsondump_00_base.t

--- a/lib/CGI/Ex/Auth.pm
+++ b/lib/CGI/Ex/Auth.pm
@@ -278,14 +278,18 @@ sub set_cookie {
     return $self->{'set_cookie'}->($self, $args) if $self->{'set_cookie'};
     my $key  = $args->{'name'};
     my $val  = $args->{'value'};
-    my $dom  = $args->{'domain'} || $self->cookie_domain;
-    my $sec  = $args->{'secure'} || $self->cookie_secure;
+    my $dom  = $args->{'domain'}   || $self->cookie_domain;
+    my $sec  = $args->{'secure'}   || $self->cookie_secure;
+    my $http = $args->{'httponly'} || $self->cookie_httponly;
+    my $same = $args->{'samesite'} || $self->cookie_samesite;
     $self->cgix->set_cookie({
         -name    => $key,
         -value   => $val,
         -path    => $args->{'path'} || $self->cookie_path($key, $val) || '/',
-        ($dom ? (-domain => $dom) : ()),
-        ($sec ? (-secure => $sec) : ()),
+        ($dom  ? (-domain   => $dom)  : ()),
+        ($sec  ? (-secure   => $sec)  : ()),
+        ($http ? (-httponly => $http) : ()),
+        ($same ? (-samesite => $same) : ()),
         ($args->{'expires'} ? (-expires => $args->{'expires'}): ()),
     });
     $self->cookies->{$key} = $val;
@@ -324,6 +328,8 @@ sub failed_sleep     { shift->{'failed_sleep'}     ||= 0              }
 sub cookie_path      { shift->{'cookie_path'}      }
 sub cookie_domain    { shift->{'cookie_domain'}    }
 sub cookie_secure    { shift->{'cookie_secure'}    }
+sub cookie_httponly  { shift->{'cookie_httponly'}  }
+sub cookie_samesite  { shift->{'cookie_samesite'}  }
 sub use_session_cookie { shift->{'use_session_cookie'} }
 sub disable_simple_cram { shift->{'disable_simple_cram'} }
 sub complex_plaintext { shift->{'complex_plaintext'} }

--- a/lib/CGI/Ex/Auth.pm
+++ b/lib/CGI/Ex/Auth.pm
@@ -991,8 +991,10 @@ described separately.
     cgix
     cleanup_user
     cookie_domain
-    cookie_secure
+    cookie_httponly
     cookie_path
+    cookie_samesite
+    cookie_secure
     cookies
     expires_min
     form
@@ -1399,6 +1401,20 @@ with a custom payload.
 
 Another option would be to only accept payloads from tokens if use_blowfish
 is set and armor was equal to "blowfish."
+
+=item C<cookie_domain> et al.
+
+The C<cookie_*> properties allow customizing the default implementation of
+C<set_cookie> for setting L</key_cookie>. The available properties are:
+
+    cookie_domain
+    cookie_httponly
+    cookie_path
+    cookie_samesite
+    cookie_secure
+
+Note: Using a value of C<"none"> for C<cookie_samesite> requires L<CGI>
+version 4.45 or greater.
 
 =back
 

--- a/t/8_auth_01_cookies.t
+++ b/t/8_auth_01_cookies.t
@@ -1,0 +1,82 @@
+# -*- Mode: Perl; -*-
+
+=head1 NAME
+
+8_auth_01_cookies.t - Testing of the CGI::Ex::Auth cookies.
+
+=cut
+
+use strict;
+use Test::More tests => 4;
+
+use CGI::Ex::Auth;
+
+{
+    package Fake::CGI::Ex;
+
+    my $cookie;
+
+    sub new         { bless {}, shift }
+    sub set_cookie  { shift; $cookie = shift }
+    sub get_cookies { +{} }
+
+    sub FAKE_reset  { undef $cookie }
+    sub FAKE_cookie { $cookie }
+}
+
+my $cgix = Fake::CGI::Ex->new;
+my $auth = CGI::Ex::Auth->new({cgix => $cgix});
+
+$auth->set_cookie({
+    name    => 'foo',
+    value   => 'bar',
+});
+is_deeply($cgix->FAKE_cookie, {
+    -name   => 'foo',
+    -path   => '/',
+    -value  => 'bar',
+}, 'set_cookie works') or diag explain $cgix->FAKE_cookie;
+$cgix->FAKE_reset;
+
+$auth->set_cookie({
+    domain  => 'example.com',
+    name    => 'foo',
+    path    => '/baz',
+    secure  => 1,
+    value   => 'bar',
+});
+is_deeply($cgix->FAKE_cookie, {
+    -domain => 'example.com',
+    -name   => 'foo',
+    -path   => '/baz',
+    -secure => 1,
+    -value  => 'bar',
+}, 'set_cookie with more args works') or diag explain $cgix->FAKE_cookie;
+$cgix->FAKE_reset;
+
+$auth->set_cookie({
+    name        => 'foo',
+    value       => 'bar',
+    samesite    => 'strict',
+});
+is_deeply($cgix->FAKE_cookie, {
+    -name       => 'foo',
+    -path       => '/',
+    -samesite   => 'strict',
+    -value      => 'bar',
+}, 'set_cookie with samesite arg works') or diag explain $cgix->FAKE_cookie;
+$cgix->FAKE_reset;
+
+my $auth2 = CGI::Ex::Auth->new({cgix => $cgix, cookie_samesite => 'lax'});
+$auth2->set_cookie({
+    name    => 'foo',
+    value   => 'bar',
+});
+is_deeply($cgix->FAKE_cookie, {
+    -name       => 'foo',
+    -path       => '/',
+    -samesite   => 'lax',
+    -value      => 'bar',
+}, 'set_cookie with cookie_samesite works') or diag explain $cgix->FAKE_cookie;
+$cgix->FAKE_reset;
+


### PR DESCRIPTION
In preparation for [new policies on cross-site cookies](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html), CGI::Ex::Auth needs to support SameSite. Adding HttpOnly as well to be even more complete.