### PR TITLE
Allow for CGI::Ex::Fill to not warn on nameless selects

### DIFF
--- a/lib/CGI/Ex/Fill.pm
+++ b/lib/CGI/Ex/Fill.pm
@@ -242,6 +242,7 @@ sub fill {
         next if ! $opts;
         my $tag    = $1;
         my $name   = get_tagval_by_key(\$tag, 'name');
+        next if ! defined($name) || ! length($name);
         my $values = $ignore->{$name} ? [] : $get_form_value->($name, 'all');
         if ($#$values != -1) {
             my $n = $opts =~ s{

--- a/t/2_fill_13_warning.t
+++ b/t/2_fill_13_warning.t
@@ -7,7 +7,7 @@
 =cut
 
 use strict;
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 # emits warnings for HTML::FIF <= 0.22
 
@@ -21,9 +21,15 @@ SKIP: {
     my $html = qq{<input type="submit" value="Commit">};
 
     my $q = CGI->new;
-
     $q->param( "name", "John Smith" );
-    my $output = CGI::Ex::Fill::form_fill($html, $q);
 
+    my $output = CGI::Ex::Fill::form_fill($html, $q);
     ok($html =~ m!<input( type="submit"| value="Commit"){2}>!);
+
+    my @warn;
+    local $SIG{'__WARN__'} = sub { push @warn, [@_] };
+
+    $html = qq{<select id="noname"><option value="foo">Foo</option></select>};
+    $output = CGI::Ex::Fill::form_fill($html, $q);
+    ok(!@warn, 'no warning if name is not set') or diag explain \@warn;
 };


### PR DESCRIPTION
CGI::Ex::Fill warns if it comes across a select without a name attr